### PR TITLE
Added sortby to target grid

### DIFF
--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -64,19 +64,14 @@ def conservative_regrid(
 
     if isinstance(data, xr.Dataset):
         regridded_data = conservative_regrid_dataset(
-            data, coords, latitude_coord).transpose(
-            *dim_order, ...
-        )
+            data, coords, latitude_coord
+        ).transpose(*dim_order, ...)
     else:
-        regridded_data = conservative_regrid_dataarray(
-            data, coords, latitude_coord).transpose(
-            *dim_order, ...
-        )
+        regridded_data = conservative_regrid_dataarray(  # type: ignore
+            data, coords, latitude_coord
+        ).transpose(*dim_order, ...)
 
-    for coord in target_ds.coords:
-        regridded_data = regridded_data.sortby(
-            coord, ascending=(target_ds[coord].diff(coord) >= 0).all()
-        )
+    regridded_data = regridded_data.reindex_like(target_ds, copy=False)
 
     return regridded_data
 

--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -63,19 +63,21 @@ def conservative_regrid(
     data = data.sortby(list(coord_names))
 
     if isinstance(data, xr.Dataset):
-        regridded_data = conservative_regrid_dataset(data, coords, latitude_coord).transpose(
+        regridded_data = conservative_regrid_dataset(
+            data, coords, latitude_coord).transpose(
             *dim_order, ...
         )
     else:
-        regridded_data = conservative_regrid_dataarray(data, coords, latitude_coord).transpose(
+        regridded_data = conservative_regrid_dataarray(
+            data, coords, latitude_coord).transpose(
             *dim_order, ...
         )
-    
+
     for coord in target_ds.coords:
         regridded_data = regridded_data.sortby(
             coord, ascending=(target_ds[coord].diff(coord) >= 0).all()
         )
-        
+
     return regridded_data
 
 

--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -58,6 +58,7 @@ def conservative_regrid(
     dim_order = list(target_ds.dims)
 
     coord_names = set(target_ds.coords).intersection(set(data.coords))
+    target_ds = target_ds.sortby(list(coord_names))
     coords = {name: target_ds[name] for name in coord_names}
     data = data.sortby(list(coord_names))
 

--- a/src/xarray_regrid/methods/most_common.py
+++ b/src/xarray_regrid/methods/most_common.py
@@ -61,16 +61,21 @@ def most_common_wrapper(
         data = data.to_dataset(name=da_name)
 
     coords = utils.common_coords(data, target_ds)
-    target_ds = target_ds.sortby(list(coords))
+    target_ds_sorted = target_ds.sortby(list(coords))
     coord_size = [data[coord].size for coord in coords]
     mem_usage = np.prod(coord_size) * np.zeros((1,), dtype=np.int64).itemsize
 
     if max_mem is not None and mem_usage > max_mem:
         result = split_combine_most_common(
-            data=data, target_ds=target_ds, time_dim=time_dim, max_mem=max_mem
+            data=data, target_ds=target_ds_sorted, time_dim=time_dim, max_mem=max_mem
         )
     else:
-        result = most_common(data=data, target_ds=target_ds, time_dim=time_dim)
+        result = most_common(data=data, target_ds=target_ds_sorted, time_dim=time_dim)
+        
+    for coord in target_ds.coords:
+        result = result.sortby(
+            coord, ascending=(target_ds[coord].diff(coord) >= 0).all()
+        )
 
     if da_name is not None:
         return result[da_name]

--- a/src/xarray_regrid/methods/most_common.py
+++ b/src/xarray_regrid/methods/most_common.py
@@ -72,10 +72,7 @@ def most_common_wrapper(
     else:
         result = most_common(data=data, target_ds=target_ds_sorted, time_dim=time_dim)
 
-    for coord in target_ds.coords:
-        result = result.sortby(
-            coord, ascending=(target_ds[coord].diff(coord) >= 0).all()
-        )
+    result = result.reindex_like(target_ds, copy=False)
 
     if da_name is not None:
         return result[da_name]

--- a/src/xarray_regrid/methods/most_common.py
+++ b/src/xarray_regrid/methods/most_common.py
@@ -61,6 +61,7 @@ def most_common_wrapper(
         data = data.to_dataset(name=da_name)
 
     coords = utils.common_coords(data, target_ds)
+    target_ds = target_ds.sortby(list(coords))
     coord_size = [data[coord].size for coord in coords]
     mem_usage = np.prod(coord_size) * np.zeros((1,), dtype=np.int64).itemsize
 

--- a/src/xarray_regrid/methods/most_common.py
+++ b/src/xarray_regrid/methods/most_common.py
@@ -71,7 +71,7 @@ def most_common_wrapper(
         )
     else:
         result = most_common(data=data, target_ds=target_ds_sorted, time_dim=time_dim)
-        
+
     for coord in target_ds.coords:
         result = result.sortby(
             coord, ascending=(target_ds[coord].diff(coord) >= 0).all()

--- a/tests/test_most_common.py
+++ b/tests/test_most_common.py
@@ -102,7 +102,7 @@ def test_coord_order_dataarray(dummy_lc_data, dummy_target_grid):
     da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
     assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
     assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-    
+
     dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
     da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
     assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
@@ -120,7 +120,7 @@ def test_coord_order_dataset(dummy_lc_data, dummy_target_grid):
     )
     assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
     assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-    
+
     dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
     ds_regrid = dummy_lc_data.regrid.most_common(
         dummy_target_grid,

--- a/tests/test_most_common.py
+++ b/tests/test_most_common.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from numpy.testing import assert_array_equal
 
 from xarray_regrid import Grid, create_regridding_dataset
 
@@ -97,40 +98,19 @@ def test_attrs_dataset(dummy_lc_data, dummy_target_grid):
     assert ds_regrid["longitude"].attrs == dummy_lc_data["longitude"].attrs
 
 
-
-def test_coord_order_dataarray(dummy_lc_data, dummy_target_grid):
-    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
-    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-
-    dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
-    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
-    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-
-    dummy_target_grid["longitude"] = list(reversed(dummy_target_grid["longitude"]))
-    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
-    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+@pytest.mark.parametrize("dataarray", [True, False])
+def test_coord_order_original(dummy_lc_data, dummy_target_grid, dataarray):
+    input_data = dummy_lc_data["lc"] if dataarray else dummy_lc_data
+    ds_regrid = input_data.regrid.most_common(dummy_target_grid)
+    assert_array_equal(ds_regrid["latitude"], dummy_target_grid["latitude"])
+    assert_array_equal(ds_regrid["longitude"], dummy_target_grid["longitude"])
 
 
-def test_coord_order_dataset(dummy_lc_data, dummy_target_grid):
-    ds_regrid = dummy_lc_data.regrid.most_common(
-        dummy_target_grid,
-    )
-    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-
-    dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
-    ds_regrid = dummy_lc_data.regrid.most_common(
-        dummy_target_grid,
-    )
-    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
-
-    dummy_target_grid["longitude"] = list(reversed(dummy_target_grid["longitude"]))
-    ds_regrid = dummy_lc_data.regrid.most_common(
-        dummy_target_grid,
-    )
-    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+@pytest.mark.parametrize("coord", ["latitude", "longitude"])
+@pytest.mark.parametrize("dataarray", [True, False])
+def test_coord_order_reversed(dummy_lc_data, dummy_target_grid, coord, dataarray):
+    input_data = dummy_lc_data["lc"] if dataarray else dummy_lc_data
+    dummy_target_grid[coord] = list(reversed(dummy_target_grid[coord]))
+    ds_regrid = input_data.regrid.most_common(dummy_target_grid)
+    assert_array_equal(ds_regrid["latitude"], dummy_target_grid["latitude"])
+    assert_array_equal(ds_regrid["longitude"], dummy_target_grid["longitude"])

--- a/tests/test_most_common.py
+++ b/tests/test_most_common.py
@@ -95,3 +95,42 @@ def test_attrs_dataset(dummy_lc_data, dummy_target_grid):
     assert ds_regrid.attrs != {}
     assert ds_regrid.attrs == dummy_lc_data.attrs
     assert ds_regrid["longitude"].attrs == dummy_lc_data["longitude"].attrs
+
+
+
+def test_coord_order_dataarray(dummy_lc_data, dummy_target_grid):
+    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
+    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+    
+    dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
+    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
+    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+
+    dummy_target_grid["longitude"] = list(reversed(dummy_target_grid["longitude"]))
+    da_regrid = dummy_lc_data["lc"].regrid.most_common(dummy_target_grid)
+    assert (da_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (da_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+
+
+def test_coord_order_dataset(dummy_lc_data, dummy_target_grid):
+    ds_regrid = dummy_lc_data.regrid.most_common(
+        dummy_target_grid,
+    )
+    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+    
+    dummy_target_grid["latitude"] = list(reversed(dummy_target_grid["latitude"]))
+    ds_regrid = dummy_lc_data.regrid.most_common(
+        dummy_target_grid,
+    )
+    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()
+
+    dummy_target_grid["longitude"] = list(reversed(dummy_target_grid["longitude"]))
+    ds_regrid = dummy_lc_data.regrid.most_common(
+        dummy_target_grid,
+    )
+    assert (ds_regrid["latitude"].data == dummy_target_grid["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == dummy_target_grid["longitude"].data).all()

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -165,7 +165,7 @@ def test_coord_order_dataarray(sample_input_data, sample_grid_ds, method):
     da_regrid = regridder(sample_grid_ds)
     assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
     assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-    
+
     sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
     da_regrid = regridder(sample_grid_ds)
     assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
@@ -176,7 +176,7 @@ def test_coord_order_dataarray(sample_input_data, sample_grid_ds, method):
     assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
     assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
 
-    
+
 def test_coord_order_dataarray_conservative(sample_input_data, sample_grid_ds):
     da_regrid = sample_input_data["d2m"].regrid.conservative(
         sample_grid_ds, latitude_coord="latitude"
@@ -205,7 +205,7 @@ def test_coord_order_dataset(sample_input_data, sample_grid_ds, method):
     ds_regrid = regridder(sample_grid_ds)
     assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
     assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-    
+
     sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
     ds_regrid = regridder(sample_grid_ds)
     assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -156,3 +156,84 @@ def test_attrs_dataset_conservative(sample_input_data, sample_grid_ds):
     assert ds_regrid.attrs == sample_input_data.attrs
     assert ds_regrid["d2m"].attrs == sample_input_data["d2m"].attrs
     assert ds_regrid["longitude"].attrs == sample_input_data["longitude"].attrs
+
+
+
+@pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
+def test_coord_order_dataarray(sample_input_data, sample_grid_ds, method):
+    regridder = getattr(sample_input_data["d2m"].regrid, method)
+    da_regrid = regridder(sample_grid_ds)
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+    
+    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
+    da_regrid = regridder(sample_grid_ds)
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
+    da_regrid = regridder(sample_grid_ds)
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    
+def test_coord_order_dataarray_conservative(sample_input_data, sample_grid_ds):
+    da_regrid = sample_input_data["d2m"].regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
+    da_regrid = sample_input_data["d2m"].regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
+    da_regrid = sample_input_data["d2m"].regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+
+@pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
+def test_coord_order_dataset(sample_input_data, sample_grid_ds, method):
+    regridder = getattr(sample_input_data.regrid, method)
+    ds_regrid = regridder(sample_grid_ds)
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+    
+    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
+    ds_regrid = regridder(sample_grid_ds)
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
+    ds_regrid = regridder(sample_grid_ds)
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+
+def test_coord_order_dataset_conservative(sample_input_data, sample_grid_ds):
+    ds_regrid = sample_input_data.regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
+    ds_regrid = sample_input_data.regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+
+    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
+    ds_regrid = sample_input_data.regrid.conservative(
+        sample_grid_ds, latitude_coord="latitude"
+    )
+    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
+    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -1,5 +1,7 @@
+from copy import deepcopy
 from pathlib import Path
 
+from numpy.testing import assert_array_equal
 import pytest
 import xarray as xr
 
@@ -14,9 +16,15 @@ CDO_DATA = {
 }
 
 
+@pytest.fixture(scope="session")
+def load_input_data() -> xr.Dataset:
+    ds = xr.open_dataset(DATA_PATH / "era5_2m_dewpoint_temperature_2000_monthly.nc")
+    return ds.compute()
+
+
 @pytest.fixture
-def sample_input_data() -> xr.Dataset:
-    return xr.open_dataset(DATA_PATH / "era5_2m_dewpoint_temperature_2000_monthly.nc")
+def sample_input_data(load_input_data) -> xr.Dataset:
+    return deepcopy(load_input_data)
 
 
 @pytest.fixture
@@ -63,9 +71,15 @@ def test_basic_regridders_da(sample_input_data, sample_grid_ds, method, cdo_file
     xr.testing.assert_allclose(da_regrid.compute(), ds_cdo["d2m"].compute())
 
 
+@pytest.fixture(scope="session")
+def load_conservative_input_data() -> xr.Dataset:
+    ds = xr.open_dataset(DATA_PATH / "era5_total_precipitation_2020_monthly.nc")
+    return ds.compute()
+
+
 @pytest.fixture
-def conservative_input_data() -> xr.Dataset:
-    return xr.open_dataset(DATA_PATH / "era5_total_precipitation_2020_monthly.nc")
+def conservative_input_data(load_conservative_input_data) -> xr.Dataset:
+    return deepcopy(load_conservative_input_data)
 
 
 @pytest.fixture
@@ -158,82 +172,49 @@ def test_attrs_dataset_conservative(sample_input_data, sample_grid_ds):
     assert ds_regrid["longitude"].attrs == sample_input_data["longitude"].attrs
 
 
+class TestCoordOrder:
+    @pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
+    @pytest.mark.parametrize("dataarray", [True, False])
+    def test_original(self, sample_input_data, sample_grid_ds, method, dataarray):
+        input_data = sample_input_data["d2m"] if dataarray else sample_input_data
+        regridder = getattr(input_data.regrid, method)
+        ds_regrid = regridder(sample_grid_ds)
+        assert_array_equal(ds_regrid["latitude"], sample_grid_ds["latitude"])
+        assert_array_equal(ds_regrid["longitude"], sample_grid_ds["longitude"])
 
-@pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
-def test_coord_order_dataarray(sample_input_data, sample_grid_ds, method):
-    regridder = getattr(sample_input_data["d2m"].regrid, method)
-    da_regrid = regridder(sample_grid_ds)
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+    @pytest.mark.parametrize("coord", ["latitude", "longitude"])
+    @pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
+    @pytest.mark.parametrize("dataarray", [True, False])
+    def test_reversed(
+        self, sample_input_data, sample_grid_ds, method, coord, dataarray
+    ):
+        input_data = sample_input_data["d2m"] if dataarray else sample_input_data
+        regridder = getattr(input_data.regrid, method)
+        sample_grid_ds[coord] = list(reversed(sample_grid_ds[coord]))
+        ds_regrid = regridder(sample_grid_ds)
+        assert_array_equal(ds_regrid["latitude"], sample_grid_ds["latitude"])
+        assert_array_equal(ds_regrid["longitude"], sample_grid_ds["longitude"])
 
-    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
-    da_regrid = regridder(sample_grid_ds)
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+    @pytest.mark.parametrize("dataarray", [True, False])
+    def test_conservative_original(
+        self, sample_input_data, sample_grid_ds, dataarray
+    ):
+        input_data = sample_input_data["d2m"] if dataarray else sample_input_data
+        ds_regrid = input_data.regrid.conservative(
+            sample_grid_ds, latitude_coord="latitude"
+        )
+        assert_array_equal(ds_regrid["latitude"], sample_grid_ds["latitude"])
+        assert_array_equal(ds_regrid["longitude"], sample_grid_ds["longitude"])
 
-    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
-    da_regrid = regridder(sample_grid_ds)
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-
-def test_coord_order_dataarray_conservative(sample_input_data, sample_grid_ds):
-    da_regrid = sample_input_data["d2m"].regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
-    da_regrid = sample_input_data["d2m"].regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
-    da_regrid = sample_input_data["d2m"].regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (da_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (da_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-
-@pytest.mark.parametrize("method", ["linear", "nearest", "cubic"])
-def test_coord_order_dataset(sample_input_data, sample_grid_ds, method):
-    regridder = getattr(sample_input_data.regrid, method)
-    ds_regrid = regridder(sample_grid_ds)
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
-    ds_regrid = regridder(sample_grid_ds)
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
-    ds_regrid = regridder(sample_grid_ds)
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-
-def test_coord_order_dataset_conservative(sample_input_data, sample_grid_ds):
-    ds_regrid = sample_input_data.regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["latitude"] = list(reversed(sample_grid_ds["latitude"]))
-    ds_regrid = sample_input_data.regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
-
-    sample_grid_ds["longitude"] = list(reversed(sample_grid_ds["longitude"]))
-    ds_regrid = sample_input_data.regrid.conservative(
-        sample_grid_ds, latitude_coord="latitude"
-    )
-    assert (ds_regrid["latitude"].data == sample_grid_ds["latitude"].data).all()
-    assert (ds_regrid["longitude"].data == sample_grid_ds["longitude"].data).all()
+    @pytest.mark.parametrize("coord", ["latitude", "longitude"])
+    @pytest.mark.parametrize("dataarray", [True, False])
+    def test_conservative_reversed(
+        self, sample_input_data, sample_grid_ds, coord, dataarray
+    ):
+        input_data = sample_input_data["d2m"] if dataarray else sample_input_data
+        sample_grid_ds[coord] = list(reversed(sample_grid_ds[coord]))
+        ds_regrid = input_data.regrid.conservative(
+            sample_grid_ds, latitude_coord="latitude"
+        )
+        assert_array_equal(ds_regrid["latitude"], sample_grid_ds["latitude"])
+        assert_array_equal(ds_regrid["longitude"], sample_grid_ds["longitude"])

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from pathlib import Path
 
-from numpy.testing import assert_array_equal
 import pytest
 import xarray as xr
+from numpy.testing import assert_array_equal
 
 import xarray_regrid
 
@@ -196,9 +196,7 @@ class TestCoordOrder:
         assert_array_equal(ds_regrid["longitude"], sample_grid_ds["longitude"])
 
     @pytest.mark.parametrize("dataarray", [True, False])
-    def test_conservative_original(
-        self, sample_input_data, sample_grid_ds, dataarray
-    ):
+    def test_conservative_original(self, sample_input_data, sample_grid_ds, dataarray):
         input_data = sample_input_data["d2m"] if dataarray else sample_input_data
         ds_regrid = input_data.regrid.conservative(
             sample_grid_ds, latitude_coord="latitude"


### PR DESCRIPTION
When regridding using the `conservative` and `most_common` methods, the plane coordinates (i.e., latitude and longitude) needed to be in increasing order in the target grid. This adds sorting of the target grid.

Fixes the issue in #28.